### PR TITLE
Fix “Messaging unqualified id” errors

### DIFF
--- a/EZForm/EZForm/src/EZForm.m
+++ b/EZForm/EZForm/src/EZForm.m
@@ -544,8 +544,8 @@
 
 - (void)keyboardWillShowNotification:(NSNotification *)notification
 {
-    _visibleKeyboardFrame = [[notification userInfo][UIKeyboardFrameEndUserInfoKey] CGRectValue];
-    _keyboardAnimationDuration = [[notification userInfo][UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+    _visibleKeyboardFrame = [(NSValue *)[notification userInfo][UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    _keyboardAnimationDuration = [(NSNumber *)[notification userInfo][UIKeyboardAnimationDurationUserInfoKey] doubleValue];
 
     EZFormField *formField = [self formFieldForFirstResponder];
     BOOL shouldAutoScroll = (self.viewToAutoScroll && (! [self.viewToAutoScroll isKindOfClass:[UITableView class]]) && formField);
@@ -566,15 +566,15 @@
     _visibleKeyboardFrame = CGRectZero;
     
     if (self.viewToAutoScroll) {
-	NSTimeInterval animationDuration = [[notification userInfo][UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+	NSTimeInterval animationDuration = [(NSNumber *)[notification userInfo][UIKeyboardAnimationDurationUserInfoKey] doubleValue];
         [self revertAutoScrolledViewAnimationDuration:animationDuration];
     }
 }
 
 - (void)keyboardWillChangeFrameNotification:(NSNotification *)notification
 {
-    _visibleKeyboardFrame = [[notification userInfo][UIKeyboardFrameEndUserInfoKey] CGRectValue];
-    _keyboardAnimationDuration = [[notification userInfo][UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+    _visibleKeyboardFrame = [(NSValue *)[notification userInfo][UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    _keyboardAnimationDuration = [(NSNumber *)[notification userInfo][UIKeyboardAnimationDurationUserInfoKey] doubleValue];
 }
 
 

--- a/EZForm/EZForm/src/EZFormBooleanField.m
+++ b/EZForm/EZForm/src/EZFormBooleanField.m
@@ -154,7 +154,7 @@ typedef enum {
 
 - (void)setActualFieldValue:(id)value
 {
-    _internalValue = [value boolValue];
+    _internalValue = [(NSNumber *)value boolValue];
 }
 
 - (UIView *)userView

--- a/EZForm/EZForm/src/EZFormCommonValidators.m
+++ b/EZForm/EZForm/src/EZFormCommonValidators.m
@@ -52,7 +52,7 @@ EZFormValidateNumericInputWithLimits(id input, NSInteger min, NSInteger max)
     
     if ([(NSString *)input length] > 0) {
 	// Restrict to specified range of numbers
-	NSInteger value = [input integerValue];
+	NSInteger value = [(NSString *)input integerValue];
 	if ((min != NSNotFound && value < min) || (max != NSNotFound && value > max)) {
 	    return NO;
 	}

--- a/EZForm/EZForm/src/EZFormContinuousField.m
+++ b/EZForm/EZForm/src/EZFormContinuousField.m
@@ -95,7 +95,7 @@
     [self.slider addTarget:self action:@selector(sliderChanged:) forControlEvents:UIControlEventValueChanged];
     self.slider.maximumValue = self.maximumValue;
     self.slider.minimumValue = self.minimumValue;
-    self.slider.value = [[self actualFieldValue] floatValue];
+    self.slider.value = [(NSNumber *)[self actualFieldValue] floatValue];
     self.slider.continuous = self.continuous;
 }
 

--- a/EZForm/EZForm/src/EZFormDateField.m
+++ b/EZForm/EZForm/src/EZFormDateField.m
@@ -115,11 +115,11 @@
 
 - (void)setActualFieldValue:(id)value
 {
-    if ([value isKindOfClass: [NSDate class]]) {
-        self.internalValue = value;
+    if ([(NSDate *)value isKindOfClass: [NSDate class]]) {
+        self.internalValue = (NSDate *)value;
     }
-    else if ([value isKindOfClass: [NSString class]]) {
-        self.internalValue = [self.inDateFormatter dateFromString: value];
+    else if ([(NSString *)value isKindOfClass: [NSString class]]) {
+        self.internalValue = [self.inDateFormatter dateFromString: (NSString *)value];
     }
     else {
         self.internalValue = nil;

--- a/EZForm/EZForm/src/EZFormInputControl.m
+++ b/EZForm/EZForm/src/EZFormInputControl.m
@@ -55,7 +55,7 @@
 - (void)awakeFromNib
 {
     [super awakeFromNib];
-    [self.subviews enumerateObjectsUsingBlock:^(id obj, __unused NSUInteger idx, BOOL *stop) {
+    [self.subviews enumerateObjectsUsingBlock:^(UILabel *obj, __unused NSUInteger idx, BOOL *stop) {
 	if ([obj isKindOfClass:[UILabel class]]) {
 	    self.wrappedView = obj;
 	    *stop = YES;
@@ -91,12 +91,12 @@
 
 - (void)setText:(NSString *)text
 {
-    [(id)self.wrappedView setText:text];
+    [(UITextField *)self.wrappedView setText:text];
 }
 
 - (NSString *)text
 {
-    return [(id)self.wrappedView text];
+    return [(UITextField *)self.wrappedView text];
 }
 
 

--- a/EZForm/EZForm/src/EZFormMultiRadioFormField.m
+++ b/EZForm/EZForm/src/EZFormMultiRadioFormField.m
@@ -71,7 +71,7 @@
 {
     [self unsetActualFieldValue:value];
 
-    if (self.mutuallyExclusiveChoice && [self.selectedChoiceKeys count] == 0 && ![value isEqual:self.mutuallyExclusiveChoice]) {
+    if (self.mutuallyExclusiveChoice && [self.selectedChoiceKeys count] == 0 && ![(NSString *)value isEqual:self.mutuallyExclusiveChoice]) {
         [self setFieldValue:self.mutuallyExclusiveChoice];
     }
 
@@ -100,7 +100,7 @@
 
 - (void)setActualFieldValue:(id)value {
     if (value) {
-        if (self.mutuallyExclusiveChoice != nil && [value isEqual:self.mutuallyExclusiveChoice]) {
+        if (self.mutuallyExclusiveChoice != nil && [(NSString *)value isEqual:self.mutuallyExclusiveChoice]) {
             [self unsetAllFieldValues];
         }
         else if ([self.selectedChoiceKeys containsObject:self.mutuallyExclusiveChoice]) {

--- a/EZForm/EZForm/src/EZFormRadioChoiceViewController.m
+++ b/EZForm/EZForm/src/EZFormRadioChoiceViewController.m
@@ -93,7 +93,7 @@
     NSString *choiceKey = [field choiceKeys][(NSUInteger)indexPath.row];
     cell.textLabel.text = [field.choices valueForKey:choiceKey];
 
-    id modelValueArray = [self.form modelValueForKey:self.radioFieldKey];
+    NSArray *modelValueArray = [self.form modelValueForKey:self.radioFieldKey];
     if (modelValueArray != nil && ![modelValueArray isKindOfClass:[NSArray class]]) {
         modelValueArray = @[modelValueArray];
     }
@@ -116,7 +116,7 @@
     EZFormRadioField *field = [self.form formFieldForKey:self.radioFieldKey];
     NSString *choiceKey = [field choiceKeys][(NSUInteger)indexPath.row];
 
-    id modelValueArray = [self.form modelValueForKey:self.radioFieldKey];
+    NSArray *modelValueArray = [self.form modelValueForKey:self.radioFieldKey];
     if (modelValueArray != nil && ![modelValueArray isKindOfClass:[NSArray class]]) {
         modelValueArray = @[modelValueArray];
     }
@@ -138,7 +138,7 @@
 
 - (void)updateCellCheckmarks
 {
-    id modelValueArray = [self.form modelValueForKey:self.radioFieldKey];
+    NSArray *modelValueArray = [self.form modelValueForKey:self.radioFieldKey];
     if (modelValueArray != nil && ![modelValueArray isKindOfClass:[NSArray class]]) {
         modelValueArray = @[modelValueArray];
     }
@@ -151,7 +151,7 @@
         NSString *choiceKey = choiceKeys[(NSUInteger)indexPath.row];
         __block BOOL selected = NO;
 
-        [(NSArray *)modelValueArray enumerateObjectsUsingBlock:^(id selection, __unused NSUInteger idx, BOOL *stop) {
+        [(NSArray *)modelValueArray enumerateObjectsUsingBlock:^(NSString *selection, __unused NSUInteger idx, BOOL *stop) {
             if ([selection isEqualToString:choiceKey]) {
                 selected = YES;
                 *stop = YES;

--- a/EZForm/EZForm/src/EZFormTextField.m
+++ b/EZForm/EZForm/src/EZFormTextField.m
@@ -282,11 +282,8 @@
 
 - (void)updateUIWithValue:(NSString *)value
 {
-    // Assume for the sake of argument that `userControl` is a label even though
-    // it might not be, in order to remove a "Messaging unqualified id" warning.
-    UILabel *assumedLabel = (UILabel *)self.userControl;
-    if ([assumedLabel respondsToSelector:NSSelectorFromString(@"setText:")]) {
-	[assumedLabel setText:value];
+    if ([self.userControl respondsToSelector:@selector(setText:)]) {
+        [self.userControl performSelector:@selector(setText:) withObject:value];
     }
     
     [self updateValidityIndicators];

--- a/EZForm/EZForm/src/EZFormTextField.m
+++ b/EZForm/EZForm/src/EZFormTextField.m
@@ -282,8 +282,11 @@
 
 - (void)updateUIWithValue:(NSString *)value
 {
-    if ([(id)self.userControl respondsToSelector:NSSelectorFromString(@"setText:")]) {
-	[(id)self.userControl setText:value];
+    // Assume for the sake of argument that `userControl` is a label even though
+    // it might not be, in order to remove a "Messaging unqualified id" warning.
+    UILabel *assumedLabel = (UILabel *)self.userControl;
+    if ([assumedLabel respondsToSelector:NSSelectorFromString(@"setText:")]) {
+	[assumedLabel setText:value];
     }
     
     [self updateValidityIndicators];


### PR DESCRIPTION
When building with Xcode 10.2.1 (10E1001) on macOS 10.14.4 (18E226) the build fails due to multiple occurrences of the error “Messaging unqualified id”. This commit casts the `id`s concerned into concrete types and allows the build to complete.