### PR TITLE
Change toolbar bar style to default

### DIFF
--- a/EZForm/EZForm/src/EZFormStandardInputAccessoryView.m
+++ b/EZForm/EZForm/src/EZFormStandardInputAccessoryView.m
@@ -78,8 +78,6 @@
 {
     self = [super initWithFrame:frame];
     if (self) {
-        self.barStyle = UIBarStyleBlackTranslucent;
-
         NSString *nextString = NSLocalizedString(@"Next", @"EZForm Standard Input Accessory view - Next");
         NSString *prevString = NSLocalizedString(@"Previous", @"EZForm Standard Input Accessory view - Previous");
 


### PR DESCRIPTION
## Summary

- Card: https://trello.com/c/MYmjl8mw

## Description of changes

in the `RESIListingDetailContactAgentViewController`, we use a toolbar which is in EZForm library, because the bar style is black translucent, the toolbar color looks odd in dark mode, so we need to change the bar style to default. 

Related PR: https://git.realestate.com.au/consumer-experience/resi-mobile-ios/pull/6248

### How to test this
See card

### Screenshots

_A picture is worth a thousands words, especially when there's 2, one before and one after._
![Before](https://media.git.realestate.com.au/user/2888/files/b79ccd00-1ab9-11ea-9d75-3cc27d9fa24c)

| Light | Dark |
| - | - |
| ![before](https://media.git.realestate.com.au/user/2888/files/2a547b00-1aaf-11ea-99f4-3041d97304b9) | ![after](https://media.git.realestate.com.au/user/2888/files/2c1e3e80-1aaf-11ea-804a-7bdf4aade639) |

### Contributor Checklist

- Tested on:
   - [x] Simulator
   - [ ] Device
- [x] Tested both dark mode and light mode if there is any UI change
- [x] Checked that there are no additional warnings
- [x] Code was formatted using `scripts/format_swift_code.sh` (or via the pre-commit hook)
- [x] Added Github labels

